### PR TITLE
Update univention-postfix-catchall.univention-config-registry-variables

### DIFF
--- a/debian/univention-postfix-catchall.univention-config-registry-variables
+++ b/debian/univention-postfix-catchall.univention-config-registry-variables
@@ -2,3 +2,4 @@
 Description[en]=Defines the prefix of the catchall address (Default: "catchall")
 Description[de]=Definiert den Prefix der catchall Adresse (Standard: "catchall")
 Type=str
+Category=service-mail


### PR DESCRIPTION
I tested the installer with this patch for  #1, seems to work fine.
The only other mandatory change was to sign the deb package with my key, because dpkg-buildpackage automatically tried to use yours...

`dpkg-buildpackage -b -kmymail@mydomain`
